### PR TITLE
Reorder memdClient struct

### DIFF
--- a/memdclient.go
+++ b/memdclient.go
@@ -26,18 +26,19 @@ func isCompressibleOp(command commandCode) bool {
 	return false
 }
 
+
 type memdClient struct {
+	lastActivity int64
+	dcpAckSize   int
+	dcpFlowRecv  int
+	closeNotify  chan bool
+	connId       string
+	closed       bool
 	parent       *Agent
 	conn         memdConn
 	opList       memdOpMap
 	errorMap     *kvErrorMap
 	features     []HelloFeature
-	closeNotify  chan bool
-	dcpAckSize   int
-	dcpFlowRecv  int
-	lastActivity int64
-	connId       string
-	closed       bool
 	lock         sync.Mutex
 }
 


### PR DESCRIPTION
I've faced the issue explained [here](https://github.com/golang/go/issues/599) compiling a client for a 386-32 arquitecture. With the change provided my issue was solved but maybe other structures should be reorderder